### PR TITLE
Add ability to custom insertion in Params

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -24,6 +24,12 @@ pub struct Params<'a>(HashMap<Cow<'a, str>, Cow<'a, str>>);
 
 impl<'a> Params<'a> {
     #[inline]
+    pub fn insert_custom<S: Into<Cow<'a, str>>>(mut self, key: S, value: S) -> Self {
+        self.insert(k.into(), v.into());
+        self
+    }
+
+    #[inline]
     pub fn gateway_interface<S: Into<Cow<'a, str>>>(mut self, gateway_interface: S) -> Self {
         self.insert("GATEWAY_INTERFACE".into(), gateway_interface.into());
         self


### PR DESCRIPTION
This commit introduces a custom method for inserting parameters into PHP-FPM requests. This was necessary because the general methods for parameter insertion might not include required parameters, such as HTTP_HOST, which is crucial for WordPress to function properly. The custom approach ensures that all necessary parameters are provided for correct operation.