### PR TITLE
chore: reduce overall dependencies by using sub-futures crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ keywords = ["fastcgi", "fcgi", "client", "tokio", "php"]
 
 [dependencies]
 bytes = "1.10.1"
-futures = { version = "0.3.31", default-features = false }
+futures-core = { version = "0.3.31", default-features = false }
+futures-util = { version = "0.3.31", default-features = false }
 thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["io-util", "sync", "time"] }
 tokio-util = { version = "0.7.15", features = ["io"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,6 @@ pub mod request;
 pub mod response;
 
 /// Re Export StreamExt for .next support
-pub use futures::stream::StreamExt;
+pub use futures_util::stream::StreamExt;
 
 pub use crate::{client::Client, error::*, params::Params, request::Request, response::Response};

--- a/src/response.rs
+++ b/src/response.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use bytes::{Bytes, BytesMut};
-use futures::stream::Stream;
+use futures_core::stream::Stream;
 use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 use tracing::debug;

--- a/tests/client_get.rs
+++ b/tests/client_get.rs
@@ -19,7 +19,7 @@ use tokio::{
     net::TcpStream,
 };
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 
 mod common;
 

--- a/tests/client_multi.rs
+++ b/tests/client_multi.rs
@@ -16,7 +16,7 @@ use fastcgi_client::{request::Request, response::Content, Client, Params};
 use std::{env::current_dir, io::Cursor};
 use tokio::net::TcpStream;
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 
 mod common;
 


### PR DESCRIPTION
Hey! After my last PR was merged, I realized that I could potentially reduce the dependencies just a little bit to make things a bit nicer.

Previously, I incorrectly assumed `StreamExt` was implemented in the futures crate which is why I imported the whole thing, but in working on my implementation for actix with this library, I realized it was actually part of `futures_util` instead.

Ultimately this is a very minor tweak, not sure if you would prefer the two dependencies over the one but it does reduce the overall build by 3 extra unused transitive-dependencies included with `futures`.

Thanks!