### PR TITLE
fix: compute padding correctly for MAX_LENGTH (0xffff) content

### DIFF
--- a/src/meta.rs
+++ b/src/meta.rs
@@ -165,7 +165,7 @@ impl Header {
             r#type,
             request_id,
             content_length,
-            padding_length: (-(content_length as i16) & 7) as u8,
+            padding_length: (0u16.wrapping_sub(content_length) & 7) as u8,
             reserved: 0,
         }
     }


### PR DESCRIPTION
The previous padding calculation used signed negation via i16, which could overflow for large content lengths. Switch to wrapping unsigned arithmetic so padding is computed correctly across the full u16 range, including 0xffff (**MAX_LENGTH**)

This can be reproduced in debug builds with large content lengths, resulting in:

```
attempt to negate with overflow
/fastcgi-client-0.11.0/src/meta.rs:168:30
stack backtrace:
0: __rustc::rust_begin_unwind

```